### PR TITLE
feat: update htmx starter to work on first run

### DIFF
--- a/starters/htmx/package.json
+++ b/starters/htmx/package.json
@@ -5,6 +5,6 @@
     "dev": "pocketbase --dir=pb_data --dev serve"
   },
   "dependencies": {
-    "pocketpages": "latest"
+    "pocketpages": "next"
   }
 }

--- a/starters/htmx/pb_hooks/pages/(site)/+layout.ejs
+++ b/starters/htmx/pb_hooks/pages/(site)/+layout.ejs
@@ -9,7 +9,7 @@
   <meta property="og:title" content="<%=meta('title') || 'htmx starter kit'%>" />
   <meta property="og:description" content="<%=meta('description') || 'htmx starter kit'%>" />
   <meta property="og:image" content="<%=meta('image') || '/android-chrome-512x512.png'%>" />
-  <meta property="og:url" content="<%=meta('path') ? `${meta('path')}` : meta('url') || `${ctx.request().url}`%>" />
+  <meta property="og:url" content="<%=meta('path') ? `${meta('path')}` : meta('url')%>" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mvp.css/1.16.0/mvp.min.css" integrity="sha512-jpAA/iIi8VCSS32SIiI0/PV7KULveoqtZirvKdjcbAbwRGuxPbM8UG9gHd3l8T6flbx6F6mdmWKmCVvYg51kKQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/htmx/2.0.3/htmx.min.js" integrity="sha512-dQu3OKLMpRu85mW24LA1CUZG67BgLPR8Px3mcxmpdyijgl1UpCM1RtJoQP6h8UkufSnaHVRTUx98EQT9fcKohw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <%- slots.head %>

--- a/starters/htmx/pb_hooks/pages/(site)/index.ejs
+++ b/starters/htmx/pb_hooks/pages/(site)/index.ejs
@@ -1,4 +1,4 @@
 <h1>htmx starter kit</h1>
 <p>This is a starter kit shows you how to use htmx.</p>
 
-Counter <button hx-get="/api/count"><%- include('/_private/count.ejs') %></button>
+Counter <button hx-get="/xpi/count"><%- include('../_private/count.ejs') %></button>

--- a/starters/htmx/pb_hooks/pages/xpi/count/index.ejs
+++ b/starters/htmx/pb_hooks/pages/xpi/count/index.ejs
@@ -1,4 +1,4 @@
 <%
   $app.store().set('count', ($app.store().get('count')||1) + 1)
 %>
-<%- include('/_private/count.ejs') %>
+<%- include('../../_private/count.ejs') %>


### PR DESCRIPTION
currently following the docs for the htmx starter doesn't work, here's what I did to get it going:

- point to xpi instead of api
- remove ctx (context) as it errors on first run
- specify folder index for count api as having it as `count.ejs` results in 404