### PR TITLE
Added Ability To Set Other Parameters

### DIFF
--- a/packages/plugins/auth/src/index.ts
+++ b/packages/plugins/auth/src/index.ts
@@ -46,7 +46,8 @@ export type OAuth2SignInOptions = {
 } & AuthOptions
 
 export type CreateUserOptions = {
-  sendVerificationEmail: boolean
+  sendVerificationEmail: boolean,
+  params?: Record<string,any>
 } & AuthOptions
 
 const safeParseJson = (value: string | undefined) => {
@@ -85,6 +86,7 @@ const authPluginFactory: PluginFactory = (config) => {
       email,
       password,
       passwordConfirm: password,
+      ...(options?.params || {})
     })
     dbg(`created user: ${user.id}`)
     if (


### PR DESCRIPTION
In the auth package, currently it is not possible to create a user if there are other NonEmpty parameters of the collection. This change allows other properties to be set during user creation.