### PR TITLE
Fix layout inside [] parameter folder not being rendered

### DIFF
--- a/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
+++ b/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
@@ -161,7 +161,10 @@ export const AfterBootstrapHandler: PagesInitializerFunc = (e) => {
         dbg(`layout`, { pathParts }, $filepath.dir(relativePath))
         do {
           const maybeLayouts = $filepath.glob(
-            $filepath.join(pagesRoot, ...pathParts, `+layout.*`)
+            $filepath
+              .join(pagesRoot, ...pathParts, `+layout.*`)
+              // Escape glob [] syntax used in parameter routing
+              .replace('[', '\\[').replace(']', '\\]')
           )
           dbg({ pathParts, maybeLayouts })
           if (maybeLayouts && maybeLayouts.length > 0) {


### PR DESCRIPTION
Files names `+layout.ejs` inside an `[paramName]` is not loaded. Using the following structure:

```
pb_hooks/
  pages/
    +layout.ejs
    orgs/
      [domain]/
        +layout.ejs
        index.ejs
```

When acessing `/orgs/testdomain/` the layout file `pb_hooks/pages/+layout.ejs` is loaded but the file `pb_hooks/pages/orgs/[domain]/+layout.ejs` does not get rendered.

See (https://github.com/benallfree/pocketpages/discussions/52)