### PR TITLE
Allow +config.js to be a function which takes globalApi

### DIFF
--- a/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
+++ b/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
@@ -5,6 +5,7 @@ import { dbg } from '../lib/debug'
 import { pagesRoot } from '../lib/helpers'
 import { loadPlugins } from '../lib/loadPlugins'
 import { Cache, PagesConfig, PagesInitializerFunc } from '../lib/types'
+import { globalApi } from '../lib/globalApi'
 
 export type Route = {
   relativePath: string
@@ -58,7 +59,11 @@ export const AfterBootstrapHandler: PagesInitializerFunc = (e) => {
     debug: false,
     ...(() => {
       try {
-        return require(configPath) as Partial<PagesConfig>
+        const mod = require(configPath)
+        if (typeof mod === 'function') {
+          return mod(globalApi) as Partial<PagesConfig>
+        }
+        return mod as Partial<PagesConfig>
       } catch (e) {
         error(`Error loading config file: ${e}`)
         return {}

--- a/packages/site/pb_hooks/pages/(main)/docs/config.md
+++ b/packages/site/pb_hooks/pages/(main)/docs/config.md
@@ -48,6 +48,25 @@ module.exports = {
 }
 ```
 
+You can also export a function that takes the [globalApi](/docs/global-api) as an argument.
+
+This allows you to leverage things like `env()` and more in your config.
+
+```javascript
+module.exports = function(api) {
+  return {
+    plugins: [
+      {
+        name: 'pocketpages-plugin-js-sdk',
+        host: api.env('POCKETPAGES_HOST'),
+      },
+      'pocketpages-plugin-ejs',
+    ],
+    debug: true,
+  };
+}
+```
+
 ## Configuration Options
 
 - **`plugins`**: An array that specifies which plugins to use and their configurations. Plugins can be specified in several ways:


### PR DESCRIPTION
This will allow access to things in globalApi like env() and enable scenarios like so:

```js
module.exports = function(api) {
  return {
    plugins: [
      {
        name: `pocketpages-plugin-ejs`,
        extensions: ['.ejs', '.md'],
        debug: api.env("POCKETPAGES_DEBUG") ? true : false,
      },
      'pocketpages-plugin-marked',
    ],
  };
}
```