### PR TITLE
Victorioberra/chore/cleanup-contributing-tips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist
 tmp
 dist
 .vscode
+pocketbase

--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ PR's are welcome.
 - Core features
 - Starter kits
 - Showcases
+
+To develop against the starters, install [bun](https://bun.sh/).
+
+- Clone the repo `git clone https://github.com/benallfree/pocketpages`
+- Download pocketbase, if you use linux, execute `download-pocketbase.sh` (you may need to `chmod +x ./pocketbase` pocketbase)
+- run `bun dev` in a new terminal at repo root, leave open.
+- For developing inside the starters, pocketbase requires a parent node_modules folder. Symbolically link the pb_folders you need to the root of the repo. For example, to develop against the auth starter: at repo root, run `ln -s ./packages/starters/auth/pb_* ./`

--- a/download-pocketbase.sh
+++ b/download-pocketbase.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+PB_VERSION=${1:-0.28.1}
+PB_URL="https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_amd64.zip"
+
+wget -O pb.zip "$PB_URL"
+
+mkdir -p dest
+unzip pb.zip -d dest
+
+mv dest/pocketbase ./pocketbase
+chmod +x ./pocketbase
+rm -rf dest pb.zip
+
+echo "Pocketbase v${PB_VERSION} downloaded and extracted to ./pocketbase"

--- a/packages/plugins/auth/package.json
+++ b/packages/plugins/auth/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",
-    "dev": "chokidar 'src/**/*' -c 'bun run build'"
+    "dev": "bun run build && chokidar 'src/**/*' -c 'bun run build'"
   },
   "dependencies": {
     "pocketpages-plugin-js-sdk": "workspace:^0.1.0"

--- a/packages/plugins/ejs/package.json
+++ b/packages/plugins/ejs/package.json
@@ -14,7 +14,7 @@
     "pocketbase-stringify": "^0.0.2"
   },
   "devDependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "@s-libs/micro-dash": "^18.0.0",
     "chokidar-cli": "^3.0.0",
     "tsup": "^8.3.6",

--- a/packages/plugins/js-sdk/package.json
+++ b/packages/plugins/js-sdk/package.json
@@ -14,7 +14,7 @@
     "pocketbase-jsvm": "^0.25.10001",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "dependencies": {
     "pocketbase-js-sdk-jsvm": "^0.25.10004"

--- a/packages/plugins/marked/package.json
+++ b/packages/plugins/marked/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@s-libs/micro-dash": "^18.0.0",
     "chokidar-cli": "^3.0.0",
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   },

--- a/packages/plugins/micro-dash/package.json
+++ b/packages/plugins/micro-dash/package.json
@@ -13,7 +13,7 @@
     "chokidar-cli": "^3.0.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "dist",

--- a/packages/plugins/sse/package.json
+++ b/packages/plugins/sse/package.json
@@ -13,7 +13,7 @@
     "pocketbase-jsvm": "^0.25.10001",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "dist",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-marked": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/auth/package.json
+++ b/packages/starters/auth/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.2",
   "dependencies": {
-    "pocketpages": "workspace:^0.17.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-auth": "workspace:^0.2.0",
     "pocketpages-plugin-js-sdk": "workspace:^0.1.0"
   },

--- a/packages/starters/daisyui-docs/package.json
+++ b/packages/starters/daisyui-docs/package.json
@@ -27,7 +27,7 @@
     "tailwindcss": "^3.4.17"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-marked": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/daisyui/package.json
+++ b/packages/starters/daisyui/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^3.4.17"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "pb_hooks",

--- a/packages/starters/htmx/package.json
+++ b/packages/starters/htmx/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "private": true,
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-sse": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/minimal/package.json
+++ b/packages/starters/minimal/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.2",
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "pockethost": {
     "instanceId": "minimal"

--- a/packages/starters/mvp/package.json
+++ b/packages/starters/mvp/package.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/benallfree/pocketpages/packages/starters/mvp"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   }
 }


### PR DESCRIPTION
Several items of cleanup:

- Added helpful linux script for downloading Pocketbase for contributors
- Bumped all workspace references as they point to an older version of pocketpages
- Fixed plugin auth not creating a ./dist folder during `bun run dev`
- Detailed instructions in the README for tips on how to get started quickly contributing