### PR TITLE
Bump all "pocketpages": "workspace:^0.16.0" references to "^0.18.0"

### DIFF
--- a/packages/plugins/ejs/package.json
+++ b/packages/plugins/ejs/package.json
@@ -14,7 +14,7 @@
     "pocketbase-stringify": "^0.0.2"
   },
   "devDependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "@s-libs/micro-dash": "^18.0.0",
     "chokidar-cli": "^3.0.0",
     "tsup": "^8.3.6",

--- a/packages/plugins/js-sdk/package.json
+++ b/packages/plugins/js-sdk/package.json
@@ -14,7 +14,7 @@
     "pocketbase-jsvm": "^0.25.10001",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "dependencies": {
     "pocketbase-js-sdk-jsvm": "^0.25.10004"

--- a/packages/plugins/marked/package.json
+++ b/packages/plugins/marked/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@s-libs/micro-dash": "^18.0.0",
     "chokidar-cli": "^3.0.0",
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   },

--- a/packages/plugins/micro-dash/package.json
+++ b/packages/plugins/micro-dash/package.json
@@ -13,7 +13,7 @@
     "chokidar-cli": "^3.0.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "dist",

--- a/packages/plugins/sse/package.json
+++ b/packages/plugins/sse/package.json
@@ -13,7 +13,7 @@
     "pocketbase-jsvm": "^0.25.10001",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3",
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "dist",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -25,7 +25,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-marked": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/auth/package.json
+++ b/packages/starters/auth/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.2",
   "dependencies": {
-    "pocketpages": "workspace:^0.17.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-auth": "workspace:^0.2.0",
     "pocketpages-plugin-js-sdk": "workspace:^0.1.0"
   },

--- a/packages/starters/daisyui-docs/package.json
+++ b/packages/starters/daisyui-docs/package.json
@@ -27,7 +27,7 @@
     "tailwindcss": "^3.4.17"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-marked": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/daisyui/package.json
+++ b/packages/starters/daisyui/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^3.4.17"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "files": [
     "pb_hooks",

--- a/packages/starters/htmx/package.json
+++ b/packages/starters/htmx/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "private": true,
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0",
+    "pocketpages": "workspace:^0.18.0",
     "pocketpages-plugin-sse": "workspace:^0.1.0"
   },
   "files": [

--- a/packages/starters/minimal/package.json
+++ b/packages/starters/minimal/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.2",
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   },
   "pockethost": {
     "instanceId": "minimal"

--- a/packages/starters/mvp/package.json
+++ b/packages/starters/mvp/package.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/benallfree/pocketpages/packages/starters/mvp"
   },
   "dependencies": {
-    "pocketpages": "workspace:^0.16.0"
+    "pocketpages": "workspace:^0.18.0"
   }
 }


### PR DESCRIPTION
Reproduction Steps:

- `git clone https://github.com/benallfree/pocketpages`
- `cd pocketpages`
- `bun install`

```
@VictorioBerra ➜ /workspaces/pocketpages (main) $ bun install
bun install v1.2.15 (df017990)
error: No matching version for workspace dependency "pocketpages". Version: "workspace:^0.16.0"
    at /workspaces/pocketpages/packages/plugins/ejs/package.json
@VictorioBerra ➜ /workspaces/pocketpages (main) $ 
```