### PR TITLE
plugin-auth not creating dist when `bun run dev`

### DIFF
--- a/packages/plugins/auth/package.json
+++ b/packages/plugins/auth/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",
-    "dev": "chokidar 'src/**/*' -c 'bun run build'"
+    "dev": "bun run build && chokidar 'src/**/*' -c 'bun run build'"
   },
   "dependencies": {
     "pocketpages-plugin-js-sdk": "workspace:^0.1.0"


### PR DESCRIPTION
Correct dev script in package.json to match how other plugins work, /dist created as expected.