### PR TITLE
Fix all example getting started commands

### DIFF
--- a/packages/site/pb_hooks/pages/(main)/docs/authentication/oauth2.md
+++ b/packages/site/pb_hooks/pages/(main)/docs/authentication/oauth2.md
@@ -12,9 +12,9 @@ OAuth2 authentication allows users to sign in using their accounts from provider
 > **Note**: PocketPages provides an authentication starter kit that includes many pre-built integrations. You can get started quickly with:
 >
 > ```bash
-> npx tiged benallfree/pocketpages/starters/auth my-auth-app
-> cd my-auth-app
-> npm i
+> mkdir auth
+> cd auth
+> npx tiged benallfree/pocketpages/packages/starters/auth . && sed -i 's/"workspace://g' package.json
 > ```
 
 ## Basic Usage

--- a/packages/site/pb_hooks/pages/(main)/docs/authentication/overview.md
+++ b/packages/site/pb_hooks/pages/(main)/docs/authentication/overview.md
@@ -222,7 +222,10 @@ Consider these factors when choosing authentication methods:
 PocketPages provides a complete authentication starter kit that demonstrates all these authentication methods working together:
 
 ```bash
-npx tiged benallfree/pocketpages/starters/auth .
+mkdir auth
+cd auth
+npx tiged benallfree/pocketpages/packages/starters/auth . && sed -i 's/"workspace://g' package.json
+pocketbase --dir=pb_data --dev serve
 ```
 
 The starter kit includes:

--- a/packages/site/pb_hooks/pages/(main)/docs/speedruns/google-oauth2/index.md
+++ b/packages/site/pb_hooks/pages/(main)/docs/speedruns/google-oauth2/index.md
@@ -5,9 +5,9 @@ This guide will walk you through setting up Google OAuth2 authentication for you
 > **Note**: PocketPages provides an authentication starter kit that includes pre-built Google OAuth2 integration. You can get started quickly with:
 >
 > ```bash
-> npx tiged benallfree/pocketpages/starters/auth my-auth-app
-> cd my-auth-app
-> npm i
+> mkdir auth
+> cd auth
+> npx tiged benallfree/pocketpages/packages/starters/auth . && sed -i 's/"workspace://g' package.json
 > ```
 
 ## 1. Create/Select Google Cloud Project

--- a/packages/site/pb_hooks/pages/(main)/docs/starter-kits.md
+++ b/packages/site/pb_hooks/pages/(main)/docs/starter-kits.md
@@ -27,9 +27,9 @@ The easiest way to get started with PocketPages is to use one of the starter kit
 The Minimal starter kit creates the absolute most minimal PocketPages app: a single `index.ejs` home page.
 
 ```bash
-npx tiged benallfree/pocketpages/starters/minimal .
-cd minimal
-npm i
+mkdir auth
+cd auth
+npx tiged benallfree/pocketpages/packages/starters/auth . && sed -i 's/"workspace://g' package.json
 pocketbase --dir=pb_data --dev serve
 ```
 
@@ -52,9 +52,12 @@ For more detail, see https://github.com/benallfree/pocketpages/blob/master/start
 The `daisyui` starter kit incorporates Daisy UI and Tailwind.
 
 ```bash
-npx tiged benallfree/pocketpages/starters/daisyui .
+mkdir daisyui
 cd daisyui
-npm i
+npx tiged benallfree/pocketpages/packages/starters/daisyui .
+rm package.json
+npm init -y
+npm install pocketpages
 pocketbase --dir=pb_data --dev serve
 ```
 
@@ -81,9 +84,12 @@ This kit helps you deploy via Github Action to fly.io. It requires `deploy-fly-m
 This kit helps you get started with the [htmx](https://htmx.org/) project. See the [starter kit README](https://github.com/benallfree/pocketpages/blob/master/starters/htmx/README.md) for more details.
 
 ```bash
-npx tiged benallfree/pocketpages/starters/htmx .
+mkdir htmx
 cd htmx
-npm i
+npx tiged benallfree/pocketpages/packages/starters/htmx .
+rm package.json
+npm init -y
+npm install pocketpages
 pocketbase --dir=pb_data --dev serve
 ```
 
@@ -96,9 +102,12 @@ This kit provides a VSCode/Cursor configuration for PocketPages. See the [starte
 This kit provides a starter kit based on the [MVP.css](https://andybrewer.github.io/mvp/) project. MVP.css is a minimal styling solution for building fast, modern web apps. It takes all the guesswork out of styling your project, leaving you to focus on features and functionality.
 
 ```bash
-npx tiged benallfree/pocketpages/starters/mvp .
+mkdir mvp
 cd mvp
-npm i
+npx tiged benallfree/pocketpages/packages/starters/mvp .
+rm package.json
+npm init -y
+npm install pocketpages
 pocketbase --dir=pb_data --dev serve
 ```
 
@@ -115,9 +124,12 @@ This kit demonstrates Multi Page App (MPA) authentication using PocketPages. It 
 - Local mail testing setup with MailDev
 
 ```bash
-npx tiged benallfree/pocketpages/starters/auth .
+mkdir auth
 cd auth
-npm i
+npx tiged benallfree/pocketpages/packages/starters/auth .
+rm package.json
+npm init -y
+npm install pocketpages
 pocketbase --dir=pb_data --dev serve
 ```
 

--- a/packages/site/pb_hooks/pages/_private/quickstart.ejs
+++ b/packages/site/pb_hooks/pages/_private/quickstart.ejs
@@ -4,9 +4,9 @@
 
 
 <div class="max-w-[320px] sm:max-w-full overflow-x-auto ">
-  <pre><code class="language-bash ">npx tiged benallfree/pocketpages/packages/starters/minimal .
+  <pre><code class="language-bash">mkdir minimal
 cd minimal
-npm install</code></pre>
+npx tiged benallfree/pocketpages/packages/starters/minimal . && sed -i 's/"workspace://g' package.json</code></pre>
 </div>
 
 <div class="text-left  overflow  text-2xl mt-5 mb-5">
@@ -14,6 +14,6 @@ npm install</code></pre>
 </div>
 <div class="max-w-[320px] sm:max-w-full overflow-x-auto ">
 
-  <pre><code class="language-bash">pocketbase --dir=minimal/pb_data --dev serve 
+  <pre><code class="language-bash">pocketbase --dir=pb_data --dev serve 
 </code></pre>
 </div>

--- a/packages/starters/auth/README.md
+++ b/packages/starters/auth/README.md
@@ -5,10 +5,10 @@ This starter kit shows how to do Multi Page App (MPA) auth using PocketPages.
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/packages/starters/auth .
+mkdir auth
 cd auth
-npm i
-pocketbase --dir=pb_data --dev serve
+npx tiged benallfree/pocketpages/packages/starters/auth . && sed -i 's/"workspace://g' package.json
+pocketbase serve --dir=pb_data --dev
 bunx maildev
 ```
 

--- a/packages/starters/daisyui-docs/README.md
+++ b/packages/starters/daisyui-docs/README.md
@@ -5,10 +5,9 @@ Demonstrates how to use Markdown pages by creating a docs site.
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/starters/daisyui-docs .
+mkdir daisyui-docs
 cd daisyui-docs
-npm i
-npm run dev
+npx tiged benallfree/pocketpages/packages/starters/daisyui-docs . && sed -i 's/"workspace://g' package.json
 pocketbase serve --dir=pb_data --dev
 
 ```

--- a/packages/starters/daisyui/README.md
+++ b/packages/starters/daisyui/README.md
@@ -5,9 +5,8 @@ This setup provides a minimal **PocketPages** app integrated with **Tailwind CSS
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/packages/starters/daisyui .
+mkdir daisyui
 cd daisyui
-npm i
-npm run dev
+npx tiged benallfree/pocketpages/packages/starters/daisyui . && sed -i 's/"workspace://g' package.json
 pocketbase serve --dir=pb_data --dev
 ```

--- a/packages/starters/htmx/README.md
+++ b/packages/starters/htmx/README.md
@@ -5,8 +5,8 @@ This starter kit is based on the [htmx](https://htmx.org/) project. It is design
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/packages/starters/htmx .
+mkdir htmx
 cd htmx
-npm i
+npx tiged benallfree/pocketpages/packages/starters/htmx . && sed -i 's/"workspace://g' package.json
 pocketbase serve --dir=pb_data --dev
 ```

--- a/packages/starters/minimal/README.md
+++ b/packages/starters/minimal/README.md
@@ -3,7 +3,8 @@
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/starters/minimal .
+mkdir minimal
 cd minimal
+npx tiged benallfree/pocketpages/packages/starters/minimal . && sed -i 's/"workspace://g' package.json
 pocketbase --dir=pb_data --dev serve
 ```

--- a/packages/starters/mvp/README.md
+++ b/packages/starters/mvp/README.md
@@ -5,7 +5,8 @@ This starter kit is based on the [MVP.css](https://andybrewer.github.io/mvp/) pr
 ## Installation
 
 ```bash
-npx tiged benallfree/pocketpages/starters/mvp .
+mkdir mvp
 cd mvp
+npx tiged benallfree/pocketpages/packages/starters/mvp . && sed -i 's/"workspace://g' package.json
 pocketbase --dir=pb_data --dev serve
 ```


### PR DESCRIPTION
All the example commands are broken. This PR fixes complaints from multiple users: https://github.com/benallfree/pocketpages/discussions/58

When you use [tiged](https://www.npmjs.com/package/tiged), you download the package.json for each starter. The package.json contains bun-specific references like `"pocketpages": "workspace:^0.17.0",`.

The command `npm i` will fail, in fact, `bun install` will fail as tiged does not download the entire monorepo.

`sed` is used to rip out the `workspace:` string and allow `npm i` to succeed.

This is not a permanent solution (since its pretty much Linux/mac only) but we have [other issues on Windows](https://github.com/benallfree/pocketpages/discussions/58#discussioncomment-13080393) which prevents PocketPages from working and a bigger fix would probably need us to switch to using a proper template system like Yeoman or something.