### PR TITLE
Allow auth plugin to pass cookieToken to js-sdk plugin

### DIFF
--- a/packages/plugins/auth/src/index.ts
+++ b/packages/plugins/auth/src/index.ts
@@ -168,6 +168,7 @@ const authPluginFactory: PluginFactory = (config) => {
           dbg(`cookie token swapped for auth record: ${authRecord.id}`)
           request.event.auth = authRecord
           request.auth = authRecord
+          request.authToken = cookieToken
         } catch (e) {
           dbg(`error fetching auth record: ${e}`)
         }

--- a/packages/plugins/js-sdk/src/index.ts
+++ b/packages/plugins/js-sdk/src/index.ts
@@ -22,11 +22,11 @@ const jsSdkPluginFactory: PluginFactory<JSSdkPluginOptions> = (
   const { globalApi } = config
   const { dbg } = globalApi
 
-  const newClient = (host: string, auth?: core.Record) => {
+  const newClient = (host: string, auth?: core.Record, authToken?: string) => {
     const pb = new PocketBase(host)
     if (auth) {
       dbg(`auth`, typeof auth, auth)
-      const token = auth.newAuthToken()
+      const token = authToken ?? auth.newAuthToken()
       pb.authStore.save(token, JSON.parse(JSON.stringify(auth)))
       dbg(
         `created new PocketBase client for ${host} with saved auth: ${auth.id} ${token}`
@@ -42,12 +42,13 @@ const jsSdkPluginFactory: PluginFactory<JSSdkPluginOptions> = (
   globalApi.pb = (options?: Partial<PocketBaseClientOptions>) => {
     const host = options?.host ?? extra?.host ?? `http://localhost:8090`
     const auth = options?.auth ?? options?.request?.auth
+    const authToken = options?.request?.authToken
     const key = `${host}-${auth?.id}`
     if (pbCache.has(key)) {
       return pbCache.get(key)
     }
     dbg(`creating new pb client for ${key}`)
-    const pb = newClient(host, auth)
+    const pb = newClient(host, auth, authToken)
     pbCache.set(key, pb)
     return pb
   }

--- a/packages/pocketpages/src/lib/types.ts
+++ b/packages/pocketpages/src/lib/types.ts
@@ -140,7 +140,8 @@ export type PagesMethods = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
 export type PagesRequest = {
   event: core.RequestEvent
-  auth?: core.Record
+  auth?: core.Record  
+  authToken?: string
   method: PagesMethods
   url: parse<string>
   formData: () => Record<string, any>


### PR DESCRIPTION
auth plugin already has the auth token, and it already verified it via `$app.findAuthRecordByToken`. Lets pass that up and plugins like js-sdk can use it verbatim preventing an unneccisary call to `auth.newAuthToken()`on every single request.