### PR TITLE
fix: escape glob syntax for layout routing with multiple params route

### DIFF
--- a/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
+++ b/packages/pocketpages/src/handlers/AfterBootstrapHandler.ts
@@ -182,8 +182,8 @@ export const AfterBootstrapHandler: PagesInitializerFunc = (e) => {
             $filepath
               .join(pagesRoot, ...pathParts, `+layout.*`)
               // Escape glob [] syntax used in parameter routing
-              .replace('[', '\\[')
-              .replace(']', '\\]')
+              .replace(/\[/g, '\\[')
+              .replace(/\]/g, '\\]')
           )
           // dbg({ pathParts, maybeLayouts })
           if (maybeLayouts && maybeLayouts.length > 0) {


### PR DESCRIPTION
This fix is the same as #53, but I forgot to test it for routes with multiple params like `pages/offers/[id]/item/[item_id]`.